### PR TITLE
Sets search state on doSearch to keep input value

### DIFF
--- a/widgets/SelectCountryWidget.js
+++ b/widgets/SelectCountryWidget.js
@@ -1909,6 +1909,7 @@ module.exports = React.createClass({
   
   doSearch(text) {
     // console.log(text);
+    this.setState({search: text});
     this.updateRows(text);
   },
   


### PR DESCRIPTION
Ran into an issue trying to use the SelectCountryWidget.   Any changes to the textinput would overwrite itselfm so only one character was being registered at a time.   I added "setState({search: text})" to the doSearch fn as a fix.