### PR TITLE
Adds onValidation prop to GiftedForm

### DIFF
--- a/mixins/ContainerMixin.js
+++ b/mixins/ContainerMixin.js
@@ -7,6 +7,8 @@ var {
   Dimensions
 } = React;
 
+var GiftedFormManager = require('../GiftedFormManager');
+
 module.exports = {
   
   propTypes: {
@@ -65,13 +67,20 @@ module.exports = {
     }
   },
 
-  componentWillMount() {
-    this._childrenWithProps = React.Children.map(this.props.children, (child) => {      
+  handleValidation() {
+    if (!this.props.onValidation) return;
+    var validation = GiftedFormManager.validate(this.props.formName);
+    this.props.onValidation(validation);
+  },
+
+  childrenWithProps() {
+    return React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
         formStyles: this.props.formStyles,
         openModal: this.props.openModal,
         formName: this.props.formName,
         navigator: this.props.navigator,
+        onValidation: this.handleValidation,
         onFocus: this.handleFocus,
         onBlur: this.handleBlur, 
       });
@@ -106,7 +115,7 @@ module.exports = {
 
           {...this.props}
         >
-          {this._childrenWithProps}
+          {this.childrenWithProps()}
         </ScrollView>
       ); 
     }
@@ -118,7 +127,7 @@ module.exports = {
 
         {...this.props}
       >
-        {this._childrenWithProps}
+        {this.childrenWithProps()}
       </View>
     );
   },

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -112,6 +112,7 @@ module.exports = {
             validationErrorMessage: null
           });
         }
+        this.props.onValidation && this.props.onValidation();
         // @todo set isvalid of modal children here
       }
     }


### PR DESCRIPTION
Now you can pass an onValidation prop to GiftedForm and it will run on every change of every widget.

If you don't pass it it does not validate, so we don't have worry about performance. Here is an example that solves @ScandyMark's #6:

```
export default class Form extends Component {
  constructor(props, context) {
    super(props, context)
    this.state = {
      isValid: false,
    }
  }

  handleValidation(validation) {
    if (this.state.isValid !== validation.isValid)
      this.setState({ isValid: validation.isValid })
  }

  render() {
    return (
      <GiftedForm
        formName="yourForm"
        validators={yourValidatorsHere}
        onValidation={this.handleValidation.bind(this)}
      >
        <GiftedForm.TextInputWidget name='fullName' />
        <GiftedForm.SubmitWidget
          title='Sign up'
          isDisabled={!this.state.isValid}
        />
      </GiftedForm>
    )
  }  
}
```