### PR TITLE
Fix GiftedForm child is null error.

### DIFF
--- a/mixins/ContainerMixin.js
+++ b/mixins/ContainerMixin.js
@@ -75,15 +75,17 @@ module.exports = {
 
   childrenWithProps() {
     return React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
-        formStyles: this.props.formStyles,
-        openModal: this.props.openModal,
-        formName: this.props.formName,
-        navigator: this.props.navigator,
-        onValidation: this.handleValidation,
-        onFocus: this.handleFocus,
-        onBlur: this.handleBlur, 
-      });
+      if (!!child) {
+        return React.cloneElement(child, {
+          formStyles: this.props.formStyles,
+          openModal: this.props.openModal,
+          formName: this.props.formName,
+          navigator: this.props.navigator,
+          onValidation: this.handleValidation,
+          onFocus: this.handleFocus,
+          onBlur: this.handleBlur, 
+        });
+      }
     });
   },
   


### PR DESCRIPTION
```
...
    <GiftedForm.SeparatorWidget />
                {this.state.isShowSwitch && (
                    <GiftedForm.SwitchWidget
                        name="test"
                        title="test"
                        image={<IconIon  name="lightbulb" />}
                    />
                )}
                <GiftedForm.SeparatorWidget />
...
```
If this.state.isShowSwitch is false,will throw an exception!