### PR TITLE
Adds value and onValue props to WidgetMixin so we can store state in Redux store

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Pass `value` prop to your widgets and `onValueChange` to your GiftedForm to stor
 
 IMPORTANT: currently only TextInputWidget and HiddenWidget support this feature. PR's are welcome for the other widgets ;)
 
-```
+```js
 import React, { AppRegistry, Component } from 'react-native'
 import { GiftedForm, GiftedFormManager } from 'react-native-gifted-form'
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,56 @@ var Component = React.createClass({
 });
 ```
 
+### Storing form's state elsewhere (could be used with Redux)
+
+Pass `value` prop to your widgets and `onValueChange` to your GiftedForm to store your state outside of GiftedFormManager's store.
+
+IMPORTANT: currently only TextInputWidget and HiddenWidget support this feature. PR's are welcome for the other widgets ;)
+
+```
+import React, { AppRegistry, Component } from 'react-native'
+import { GiftedForm, GiftedFormManager } from 'react-native-gifted-form'
+
+class Form extends Component {
+  constructor(props, context) {
+    super(props, context)
+    this.state = {
+      form: {
+        fullName: 'Marco Polo',
+        tos: false,
+      }
+    }
+  }
+
+  handleValueChange(values) {
+    console.log('handleValueChange', values)
+    this.setState({ form: values })
+  }
+
+  render() {
+    const { fullName, tos, gender } = this.state.form
+    console.log('render', this.state.form)
+    return (
+      <GiftedForm
+        formName='signupForm'
+        openModal={(route) => { this.props.navigator.push(route) }}
+        onValueChange={this.handleValueChange.bind(this)}
+      >
+        <GiftedForm.TextInputWidget
+          name='fullName'
+          title='Full name'
+          placeholder='Marco Polo'
+          clearButtonMode='while-editing'
+          value={fullName}
+        />
+        <GiftedForm.HiddenWidget name='tos' value={tos} />
+      </GiftedForm>
+    )
+  }
+}
+
+AppRegistry.registerComponent('Form', () => Form)
+```
 
 ### Installation
 

--- a/mixins/ContainerMixin.js
+++ b/mixins/ContainerMixin.js
@@ -73,6 +73,12 @@ module.exports = {
     this.props.onValidation(validation);
   },
 
+  handleValueChange() {
+    if (!this.props.onValueChange) return;
+    var values = GiftedFormManager.getValues(this.props.formName);
+    this.props.onValueChange(values);
+  },
+
   childrenWithProps() {
     return React.Children.map(this.props.children, (child) => {
       if (!!child) {
@@ -81,9 +87,10 @@ module.exports = {
           openModal: this.props.openModal,
           formName: this.props.formName,
           navigator: this.props.navigator,
-          onValidation: this.handleValidation,
           onFocus: this.handleFocus,
           onBlur: this.handleBlur, 
+          onValidation: this.handleValidation,
+          onValueChange: this.handleValueChange,
         });
       }
     });

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -50,10 +50,7 @@ module.exports = {
   componentDidMount() {
     // get value from prop
     if (typeof this.props.value !== 'undefined') {
-      this.setState({
-        value: this.props.value,
-      });
-      this._validate(this.props.value);
+      this._setValue(this.props.value);
       return;
     }
     // get value from store

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -27,7 +27,7 @@ module.exports = {
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func,
     // If we want to store the state elsewhere (Redux store, for instance), we can use value and onValue prop
-    value: React.PropTypes.string,
+    value: React.PropTypes.any,
     onValue: React.PropTypes.func,
   },
   

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -69,7 +69,7 @@ module.exports = {
   },
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value && nextProps.value !== this.props.value) {
+    if (typeof nextProps.value !== 'undefined' && nextProps.value !== this.props.value) {
       this._onChange(nextProps.value);
     }
   },

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -26,9 +26,8 @@ module.exports = {
     // navigator: ,
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func,
-    // If we want to store the state elsewhere (Redux store, for instance), we can use value and onValue prop
+    // If we want to store the state elsewhere (Redux store, for instance), we can use value and Form's onValueChange prop
     value: React.PropTypes.any,
-    onValue: React.PropTypes.func,
   },
   
   getDefaultProps() {
@@ -143,7 +142,7 @@ module.exports = {
     this._setValue(value);
     this._validate(value);
 
-    this.props.onValue && this.props.onValue(value);
+    this.props.onValueChange && this.props.onValueChange();
     
     // @todo modal widgets validation - the modalwidget row should inform about validation status
   },

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -26,6 +26,9 @@ module.exports = {
     // navigator: ,
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func,
+    // If we want to store the state elsewhere (Redux store, for instance), we can use value and onValue prop
+    value: React.PropTypes.string,
+    onValue: React.PropTypes.func,
   },
   
   getDefaultProps() {
@@ -45,6 +48,14 @@ module.exports = {
   },
   
   componentDidMount() {
+    // get value from prop
+    if (typeof this.props.value !== 'undefined') {
+      this.setState({
+        value: this.props.value,
+      });
+      this._validate(this.props.value);
+      return;
+    }
     // get value from store
     var formState = GiftedFormManager.stores[this.props.formName];
     if (typeof formState !== 'undefined') {
@@ -56,7 +67,13 @@ module.exports = {
       }
     }
   },
-  
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value && nextProps.value !== this.props.value) {
+      this._onChange(nextProps.value);
+    }
+  },
+
   // get the styles by priority
   // defaultStyles < formStyles < widgetStyles
   getStyle(styleNames = []) {
@@ -128,6 +145,8 @@ module.exports = {
   _onChange(value) {
     this._setValue(value);
     this._validate(value);
+
+    this.props.onValue && this.props.onValue(value);
     
     // @todo modal widgets validation - the modalwidget row should inform about validation status
   },

--- a/widgets/ModalWidget.js
+++ b/widgets/ModalWidget.js
@@ -161,7 +161,9 @@ module.exports = React.createClass({
         navigator: this.props.navigator,
         onFocus: this.props.onFocus,
         onBlur: this.props.onBlur,
-        
+        onValidation: this.props.onValidation,
+        onValueChange: this.props.onValueChange,
+       
         onClose: this.onClose,        
       });
     });

--- a/widgets/SelectWidget.js
+++ b/widgets/SelectWidget.js
@@ -35,6 +35,8 @@ module.exports = React.createClass({
         navigator: this.props.navigator,
         onFocus: this.props.onFocus,
         onBlur: this.props.onBlur, 
+        onValidation: this.props.onValidation,
+        onValueChange: this.props.onValueChange,
         
         name: this.props.name+'{'+val+'}',
         ref: this.props.name+'{'+val+'}',


### PR DESCRIPTION
```
class Form extends Component {
  render() {
    return (
      <GiftedForm formName="yourForm">
        <GiftedForm.TextInputWidget
          name='fullName'
          value={this.props.yourReduxReducer.fullName}
          onValue={yourReduxActionThatWillReceiveValue}
        />
      </GiftedForm>
    )
  }  
}

export default connect(state => ({
  yourReduxReducer: state.yourReduxReducer,
}))(Form)
```

What do you think, @FaridSafi? I believe it is 100% compatible with old usage and ads capability to use it with Redux/Flux.