### PR TITLE
Adds focus method to WidgetMixin and implements it for TextInputWidget

### DIFF
--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -106,6 +106,10 @@ module.exports = {
     return styles;
   },
   
+  focus() {
+    this.refs.input && this.refs.input.focus()
+  },
+
   _validate(value) {
     if (typeof value === 'undefined') {
       value = this.state.value;

--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -55,6 +55,7 @@ module.exports = React.createClass({
           </View>
           
           <TextInput
+            ref='input'
             style={this.getStyle(['textInput'])}
           
             {...this.props}
@@ -77,6 +78,7 @@ module.exports = React.createClass({
           {this._renderImage()}
           {this._renderTitle()}
           <TextInput
+            ref='input'
             style={this.getStyle(['textInputInline'])}
 
             {...this.props}


### PR DESCRIPTION
@FaridSafi, i've implemented a very simple way to focus on text inputs from the parent of a TextInputWidget.

Over time we can make WidgetMixin#focus more complex, or override it on specific widgets to make them able to focus correctly. But I started with this baby step for now ;)

What do you say?