### PR TITLE
Switch onchange property

### DIFF
--- a/widgets/SwitchWidget.js
+++ b/widgets/SwitchWidget.js
@@ -14,7 +14,7 @@ var GiftedSwitch = React.createClass({
   _getSwitch() {
     if (Platform.OS === 'android') {
       return (
-        <SwitchAndroid 
+        <SwitchAndroid
           {...this.props}
         />
       );
@@ -39,26 +39,29 @@ var GiftedSwitch = React.createClass({
 
 module.exports = React.createClass({
   mixins: [WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'SwitchWidget',
     };
   },
-  
+
   render() {
     return (
       <View style={this.getStyle('rowContainer')}>
         <View style={this.getStyle('row')}>
           {this._renderImage()}
-      
+
           <Text numberOfLines={1} style={this.getStyle('switchTitle')}>{this.props.title}</Text>
           <View style={this.getStyle('switchAlignRight')}>
             <GiftedSwitch
               style={this.getStyle('switch')}
               {...this.props}
-        
-              onValueChange={this._onChange}
+
+              onValueChange={(value) => {
+                this._onChange(value);
+                this.props.onChange && this.props.onChange(value);
+              }}
               value={this.state.value}
             />
           </View>
@@ -67,7 +70,7 @@ module.exports = React.createClass({
       </View>
     );
   },
-  
+
   defaultStyles: {
     rowImage: {
       height: 20,
@@ -96,6 +99,6 @@ module.exports = React.createClass({
       marginRight: 10,
     },
     switch: {
-    },  
+    },
   },
 });


### PR DESCRIPTION
Allows a user to specify an `onChange` property for switches.

### Example usage:

```js
<GiftedForm.SwitchWidget
  name='shippingEnabled'
  title='Charge Shipping?'
  ref='shippingEnabled'
  onChange={(value) => {
    console.log('Shipping enabled switched changed to: ' + value)
    this.forceUpdate()
  }}
/>
```

My editor made some whitespace fixes automatically as well. You can view this PR with `?w=1` at the end to get rid of these in the file viewer: https://github.com/FaridSafi/react-native-gifted-form/pull/44/files?w=1