### PR TITLE
Bug fix - cannot use dynamic strings within image require statements

### DIFF
--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -212,7 +212,7 @@ module.exports = {
     const shouldShowValidationImage = this.props.validationImage === true;
 
     if (hasValue && hasImageProp && !isOptionWidget && shouldShowValidationImage && toValidate) {
-      const imageSrc = hasValidationErrors ? require('../icons/delete_sign.png'):require('../icons/checkmark.png');;
+      const imageSrc = hasValidationErrors ? require('../icons/delete_sign.png'):require('../icons/checkmark.png');
 
       return (
         <Image

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -218,7 +218,7 @@ module.exports = {
         <Image
           style={this.getStyle('rowImage')}
           resizeMode={Image.resizeMode.contain}
-          source={require(`../icons/${imageSrc}`)}
+          source={{ uri: `../icons/${imageSrc}` }}
         />
       );
     } else if (hasImageProp) {

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -212,13 +212,13 @@ module.exports = {
     const shouldShowValidationImage = this.props.validationImage === true;
 
     if (hasValue && hasImageProp && !isOptionWidget && shouldShowValidationImage && toValidate) {
-      const imageSrc = hasValidationErrors ? 'delete_sign.png' : 'checkmark.png';
+      const imageSrc = hasValidationErrors ? require('../icons/delete_sign.png'):require('../icons/checkmark.png');;
 
       return (
         <Image
           style={this.getStyle('rowImage')}
           resizeMode={Image.resizeMode.contain}
-          source={{ uri: `../icons/${imageSrc}` }}
+          source={imageSrc}
         />
       );
     } else if (hasImageProp) {

--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -19,6 +19,7 @@ module.exports = React.createClass({
       type: 'TextInputWidget',
       underlined: false,
       onTextInputFocus: (value) => value,
+      onTextInputBlur: (value) => value
     }
   },
   
@@ -115,6 +116,7 @@ module.exports = React.createClass({
       focused: false,
     });    
     this.props.onBlur();
+    this.props.onTextInputBlur(this.state.value);
   },
   
   


### PR DESCRIPTION
This PR is related to #61.

The JavaScript files need to be statically analyzed in order to be bundled. You cannot use dynamic strings.  I have tested the forked repo in our app and it works as expected.

For more info, checkout: https://github.com/facebook/react-native/issues/2481