### PR TITLE
Main: Moved Validation Errors Generation. GooglePlaces Widget: Exposed Request. ModalWidget: Implemented display title rather than value.

### DIFF
--- a/GiftedFormManager.js
+++ b/GiftedFormManager.js
@@ -219,6 +219,27 @@ class Manager {
     return {isValid: true, results};
   }
 
+  getValidationErrors(validated, notValidMessage = 'Invalid', requiredMessage = 'Required') {
+    var errors = [];
+    if (validated.isValid === false) {
+      for (var k in validated.results) {
+        if (validated.results.hasOwnProperty(k)) {
+          for (var j in validated.results[k]) {
+            if (validated.results[k].hasOwnProperty(j)) {
+              if (validated.results[k][j].isValid === false) {
+                let defaultMessage = !!validated.results[k][j].value ? notValidMessage : requiredMessage;
+                errors.push(validated.results[k][j].message || defaultMessage.replace('{TITLE}', validated.results[k][j].title));
+                // displaying only 1 error per widget
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    return errors;
+  }
+  
   getValues(formName) {
     if (typeof this.stores[formName] !== 'undefined') {
       return formatValues(this.stores[formName].values);

--- a/GiftedFormManager.js
+++ b/GiftedFormManager.js
@@ -219,7 +219,7 @@ class Manager {
     return {isValid: true, results};
   }
 
-  getValidationErrors(validated, notValidMessage = 'Invalid', requiredMessage = 'Required') {
+  getValidationErrors(validated, notValidMessage = '{TITLE} Invalid', requiredMessage = '{TITLE} Required') {
     var errors = [];
     if (validated.isValid === false) {
       for (var k in validated.results) {

--- a/widgets/GooglePlacesWidget.js
+++ b/widgets/GooglePlacesWidget.js
@@ -7,17 +7,17 @@ var {GooglePlacesAutocomplete} = require('react-native-google-places-autocomplet
 
 module.exports = React.createClass({
   mixins: [WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'GooglePlacesWidget',
     };
   },
-  
+
   render() {
     const everywhere = {description: 'Everywhere', geometry: { location: { lat: 0, lng: 0 } }};
-    
-    
+
+
     return (
       <GooglePlacesAutocomplete
         placeholder='Type a city name'
@@ -25,10 +25,10 @@ module.exports = React.createClass({
         autoFocus={false}
         fetchDetails={true}
         onPress={(data, details = {}) => { // details is provided when fetchDetails = true
-          // console.log(details);
           this._onChange({
             name: details.formatted_address,
             placeId: details.place_id,
+            details: details,
             loc: [details.geometry.location.lng, details.geometry.location.lat],
             types: details.types
           });
@@ -46,7 +46,7 @@ module.exports = React.createClass({
             color: '#1faadb',
           },
         }}
-        
+
         currentLocation={true} // Will add a 'Current location' button at the top of the predefined places list
         currentLocationLabel="Current location"
         currentLocationAPI='GoogleReverseGeocoding' // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
@@ -58,13 +58,13 @@ module.exports = React.createClass({
           rankby: 'distance',
           types: 'food',
         }}
-        
-        
+
+
         filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities
-        
+
         // predefinedPlaces={[everywhere]}
-        
-        
+
+
         {...this.props} // @todo test sans (need for 'name')
       />
     );

--- a/widgets/ModalWidget.js
+++ b/widgets/ModalWidget.js
@@ -234,9 +234,31 @@ module.exports = React.createClass({
                   return this.props.transformValue(values[this.props.displayValue]);
                 } else {
                   if (Array.isArray(values[this.props.displayValue])) {
-                    // @todo
-                    // should return the title and not the value in case of select menu
-                    return values[this.props.displayValue].join(', ');
+                    
+                    var value = values[this.props.displayValue].join(', ');
+
+                    // extract the title from the SelectWidget
+                    if(value !== 'undefined' && this.props.children !== 'undefined') {
+                      // find the select
+                      for(var s in this.props.children) {
+                        if(this.props.children[s].props.type == 'SelectWidget') {
+                          if(this.props.children[s].props.children !== 'undefined') {
+                            // find the associated option
+                            for(var o in this.props.children[s].props.children) {
+                              if(this.props.children[s].props.children[o].props.value === value) {
+                                // if the title is set, use that
+                                if(this.props.children[s].props.children[o].props.title !== 'undefined') {
+                                  return this.props.children[s].props.children[o].props.title;
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+
+                    return value;
+
                   } else if (values[this.props.displayValue] instanceof Date) {
                     return moment(values[this.props.displayValue]).calendar(null, {
                       sameDay: '[Today]',

--- a/widgets/SubmitWidget.js
+++ b/widgets/SubmitWidget.js
@@ -41,28 +41,6 @@ module.exports = React.createClass({
     };
   },
 
-  onValidationError(validated) {
-    var errors = [];
-    if (validated.isValid === false) {
-      for (var k in validated.results) {
-        if (validated.results.hasOwnProperty(k)) {
-          for (var j in validated.results[k]) {
-            if (validated.results[k].hasOwnProperty(j)) {
-              if (validated.results[k][j].isValid === false) {
-                let defaultMessage = !!validated.results[k][j].value ? this.props.notValidMessage : this.props.requiredMessage;
-                errors.push(validated.results[k][j].message || defaultMessage.replace('{TITLE}', validated.results[k][j].title));
-                // displaying only 1 error per widget
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    this.props.form.setState({errors});
-  },
-
   clearValidationErrors() {
     this.props.form.setState({errors: []});
   },
@@ -89,7 +67,12 @@ module.exports = React.createClass({
       });
       this.props.onSubmit(true, values, validationResults, this._postSubmit, this.props.navigator);
     } else {
-      this.onValidationError(validationResults);
+      var errors = this.getValidationErrors(
+        validationResults,
+        this.props.notValidMessage,
+        this.props.requiredMesage
+      );
+      this.props.form.setState({errors: errors});
       this.props.onSubmit(false, values, validationResults, this._postSubmit, this.props.navigator);
     }
   },

--- a/widgets/SubmitWidget.js
+++ b/widgets/SubmitWidget.js
@@ -67,7 +67,7 @@ module.exports = React.createClass({
       });
       this.props.onSubmit(true, values, validationResults, this._postSubmit, this.props.navigator);
     } else {
-      var errors = this.getValidationErrors(
+      var errors = GiftedFormManager.getValidationErrors(
         validationResults,
         this.props.notValidMessage,
         this.props.requiredMesage


### PR DESCRIPTION
Hi,

The issue: I don't want to use the submit widget to submit my forms, I want to use a button the navigation bar. (it could be any button). Putting the error generation as part of the SubmitWidget assumes too much about how I want to submit the form. 

The module currently generates errors as part of the submit widget. I have extracted that functionality out and added it as a utility method as: GiftedFormManager.getValidationErrors.

This means in my navigation by I can use it as follows:

```

            action: () => {
              // get the validation results
              var validationResults = GiftedFormManager.validate(this._form.props.formName);

              // is the form valid?
              if(validationResults.isValid) {
                // get the values
                var values = GiftedFormManager.getValues(this._form.props.formName);
                // dispatch to add booking
                this.props.store.job.addBooking(values);
                // remove the scene
                Ugo.Actions.pop();
              }
              else {
                // get the errors
                var errors = GiftedFormManager.getValidationErrors(validationResults);

                // update the form's state with the errors
                this._form.setState({errors});
              }
            }

```

The change is transparent to the current SubmitWidget. 
