### PR TITLE
Allow passing image={{uri: 'http:...'}}

### DIFF
--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -225,7 +225,7 @@ module.exports = {
         />
       );
     } else if (hasImageProp) {
-      if (typeof this.props.image === 'object') {
+      if (typeof this.props.image === 'object' && this.props.image.isReactComponent) {
         return(this.props.image);
       }
 


### PR DESCRIPTION
These quality as objects, but are not React Components. So let them fall-through to use the normal <Image source={this.props.image} /> code.