### PR TITLE
Allows a react element for title

### DIFF
--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -16,7 +16,10 @@ module.exports = {
 
   propTypes: {
     name: React.PropTypes.string,
-    title: React.PropTypes.string,
+    title: React.PropTypes.oneOf([
+        React.PropTypes.string,
+        React.PropTypes.element,
+    ]),
     formName: React.PropTypes.string,
     // image: ,
     widgetStyles: React.PropTypes.object,


### PR DESCRIPTION
I'm not sure if this is going to be acceptable, but I thought I'd give it a shot. I was using this library and wanted to put styled text in a NoticeWidget. However, this library warns on that because the proptype of title is string only. Because the widget mixin supplies the proptypes for everything I think it's difficult for me to just change the proptypes of the noticewidget. 

So, I'm hoping that this library can support <Text /> in the title and that we can figure out a nice way to make that happen. 