### PR TITLE
Fix references to SwitchAndroid and SwitchIOS

### DIFF
--- a/widgets/SwitchWidget.js
+++ b/widgets/SwitchWidget.js
@@ -2,8 +2,7 @@ var React = require('react');
 var {
   View,
   Text,
-  SwitchIOS,
-  SwitchAndroid,
+  Switch,
   Platform,
   PixelRatio
 } = require('react-native')
@@ -12,19 +11,11 @@ var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 var GiftedSwitch = React.createClass({
   _getSwitch() {
-    if (Platform.OS === 'android') {
-      return (
-        <SwitchAndroid
-          {...this.props}
-        />
-      );
-    } else {
-      return (
-        <SwitchIOS
-          {...this.props}
-        />
-      );
-    }
+    return (
+      <Switch
+        {...this.props}
+      />
+    );
   },
   render() {
     return (


### PR DESCRIPTION
Replaces the deprecated platform-specific switches with regular `Switch`. See the [release notes](https://github.com/facebook/react-native/releases/tag/v0.37.0) for React Native v0.37 for more info!