### PR TITLE
Fixed margins on text input when inline is set to false.

### DIFF
--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -203,7 +203,8 @@ module.exports = React.createClass({
       fontSize: 15,
       flex: 1,
       height: 40,
-      marginLeft: 40,
+      marginLeft: 7,
+      marginRight: 7,
     },
   },
 });


### PR DESCRIPTION
Margins were not correct when using a TextInputWidget with inline set to false:

<img width="302" alt="screen shot 2016-12-05 at 8 29 10 am" src="https://cloud.githubusercontent.com/assets/7729839/20888237/fb66d0b8-bacb-11e6-99f6-bbfe6f15e2ae.png">


Is now:

<img width="302" alt="screen shot 2016-12-05 at 9 20 41 am" src="https://cloud.githubusercontent.com/assets/7729839/20888274/26e6d30a-bacc-11e6-949c-95e4da569d0f.png">

