### PR TITLE
Programmatic Submit

### DIFF
--- a/GiftedFormManager.js
+++ b/GiftedFormManager.js
@@ -297,6 +297,27 @@ class Manager {
       this.stores[obj.formName].values[obj.name] = obj.value;
     }
   }
+
+  getValidationErrors(validated, notValidMessage = '{TITLE} Invalid', requiredMessage = '{TITLE} Required') {
+    var errors = [];
+    if (validated.isValid === false) {
+      for (var k in validated.results) {
+        if (validated.results.hasOwnProperty(k)) {
+          for (var j in validated.results[k]) {
+            if (validated.results[k].hasOwnProperty(j)) {
+              if (validated.results[k][j].isValid === false) {
+                let defaultMessage = !!validated.results[k][j].value ? notValidMessage : requiredMessage;
+                errors.push(validated.results[k][j].message || defaultMessage.replace('{TITLE}', validated.results[k][j].title));
+                // displaying only 1 error per widget
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    return errors;
+  }
 }
 
 module.exports = new Manager();

--- a/widgets/GooglePlacesWidget.js
+++ b/widgets/GooglePlacesWidget.js
@@ -7,17 +7,17 @@ var {GooglePlacesAutocomplete} = require('react-native-google-places-autocomplet
 
 module.exports = React.createClass({
   mixins: [WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'GooglePlacesWidget',
     };
   },
-  
+
   render() {
     const everywhere = {description: 'Everywhere', geometry: { location: { lat: 0, lng: 0 } }};
-    
-    
+
+
     return (
       <GooglePlacesAutocomplete
         placeholder='Type a city name'
@@ -29,6 +29,7 @@ module.exports = React.createClass({
           this._onChange({
             name: details.formatted_address,
             placeId: details.place_id,
+            details: details,
             loc: [details.geometry.location.lng, details.geometry.location.lat],
             types: details.types
           });
@@ -46,7 +47,7 @@ module.exports = React.createClass({
             color: '#1faadb',
           },
         }}
-        
+
         currentLocation={true} // Will add a 'Current location' button at the top of the predefined places list
         currentLocationLabel="Current location"
         currentLocationAPI='GoogleReverseGeocoding' // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
@@ -58,13 +59,13 @@ module.exports = React.createClass({
           rankby: 'distance',
           types: 'food',
         }}
-        
-        
+
+
         filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities
-        
+
         // predefinedPlaces={[everywhere]}
-        
-        
+
+
         {...this.props} // @todo test sans (need for 'name')
       />
     );

--- a/widgets/SubmitWidget.js
+++ b/widgets/SubmitWidget.js
@@ -41,28 +41,6 @@ module.exports = React.createClass({
     };
   },
 
-  onValidationError(validated) {
-    var errors = [];
-    if (validated.isValid === false) {
-      for (var k in validated.results) {
-        if (validated.results.hasOwnProperty(k)) {
-          for (var j in validated.results[k]) {
-            if (validated.results[k].hasOwnProperty(j)) {
-              if (validated.results[k][j].isValid === false) {
-                let defaultMessage = !!validated.results[k][j].value ? this.props.notValidMessage : this.props.requiredMessage;
-                errors.push(validated.results[k][j].message || defaultMessage.replace('{TITLE}', validated.results[k][j].title));
-                // displaying only 1 error per widget
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    this.props.form.setState({errors});
-  },
-
   clearValidationErrors() {
     this.props.form.setState({errors: []});
   },
@@ -89,7 +67,12 @@ module.exports = React.createClass({
       });
       this.props.onSubmit(true, values, validationResults, this._postSubmit, this.props.navigator);
     } else {
-      this.onValidationError(validationResults);
+      var errors = GiftedFormManager.getValidationErrors(
+        validationResults,
+        this.props.notValidMessage,
+        this.props.requiredMesage
+      );
+      this.props.form.setState({errors: errors});
       this.props.onSubmit(false, values, validationResults, this._postSubmit, this.props.navigator);
     }
   },


### PR DESCRIPTION
Hi @cooperka,

Glad to see someone is taking control of this repo. Any chance I can get the following merged in? 

1) Moved error generation to GiftedManager so that the form may be submitted programmatically


```
// submit action
() => {
    var validationResults = GiftedFormManager.validate(this._form.props.formName);
    if (validationResults.isValid) {
        // do processing
        return;
    }
    
    // get the generation errors
    var errors = GiftedFormManager.getValidationErrors(validationResults);

    // update the form's state with the errors
     this._form.setState({errors});
}
```

2) Exposed the google places response details in GooglePlacesWidget

This is just to give access to the underlying response as there are elements I personally required and there is no halm in exposing them. 