### PR TITLE
Add generic "RowValueWidget" that just displays the given value 

### DIFF
--- a/GiftedForm.js
+++ b/GiftedForm.js
@@ -20,6 +20,7 @@ const NoticeWidget = require('./widgets/NoticeWidget');
 const ValidationErrorWidget = require('./widgets/ValidationErrorWidget');
 const GooglePlacesWidget = require('./widgets/GooglePlacesWidget');
 const RowWidget = require('./widgets/RowWidget');
+const RowValueWidget = require('./widgets/RowValueWidget');
 const LoadingWidget = require('./widgets/LoadingWidget');
 const HiddenWidget = require('./widgets/HiddenWidget');
 const ErrorsWidget = require('./widgets/ErrorsWidget');
@@ -42,6 +43,7 @@ const GiftedForm = React.createClass({
     NoticeWidget,
     GooglePlacesWidget,
     RowWidget,
+    RowValueWidget,
     LoadingWidget,
     HiddenWidget,
     ValidationErrorWidget,

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ AppRegistry.registerComponent('Form', () => Form)
 - HiddenWidget - A non-displayed widget. The value will be passed to SubmitWidget
 - LoadingWidget - A loader
 - RowWidget - A touchable row with title/image
+- RowValueWidget - A touchable row with title/image and a value
 - SelectCountryWidget - A country picker. Flags made by www.IconDrawer.com
 - SelectWidget - A select menu
 - SeparatorWidget - A 10px widgets separator

--- a/widgets/RowValueWidget.js
+++ b/widgets/RowValueWidget.js
@@ -1,0 +1,84 @@
+var React = require('react');
+var {
+  View,
+  Text,
+  TouchableHighlight,
+  Image,
+  PixelRatio
+} = require('react-native')
+
+var WidgetMixin = require('../mixins/WidgetMixin.js');
+var TimerMixin = require('react-timer-mixin');
+
+
+module.exports = React.createClass({
+  mixins: [TimerMixin, WidgetMixin],
+  
+  getDefaultProps() {
+    return {
+      type: 'RowValueWidget',
+      onPress: () => {},
+      disclosure: true,
+    };
+  },
+  
+  render() {
+    return (
+      <View style={this.getStyle('rowContainer')}>
+        <TouchableHighlight
+          onPress={() => {
+            this.requestAnimationFrame(() => {
+              this.props.onPress();
+            });
+          }}
+          underlayColor={this.getStyle('underlayColor').pop()}
+          {...this.props} // mainly for underlayColor
+        >
+          <View style={this.getStyle('row')}>
+            {this._renderImage()}
+            <Text numberOfLines={1} style={this.getStyle('title')}>{this.props.title}</Text>
+            <View style={this.getStyle('alignRight')}>
+              <Text numberOfLines={1} style={this.getStyle('value')}>{this.state.value}</Text>
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    );
+  },
+  
+  defaultStyles: {
+    rowImage: {
+      height: 20,
+      width: 20,
+      marginLeft: 10,
+    },
+    rowContainer: {
+      backgroundColor: '#FFF',
+      borderBottomWidth: 1 / PixelRatio.get(),
+      borderColor: '#c8c7cc',
+    },
+    row: {
+      flexDirection: 'row',
+      height: 44,
+      alignItems: 'center',
+    },
+    underlayColor: '#c7c7cc',
+    disclosure: {
+      transform: [{rotate: '-90deg'}],
+      marginLeft: 10,
+      marginRight: 10,
+      width: 11,
+    },
+    title: {
+      flex: 1,
+      fontSize: 15,
+      color: '#000',
+      paddingLeft: 10,
+    },
+    value: {
+      fontSize: 15,
+      color: '#c7c7cc',
+      paddingRight: 10,
+    },
+  },
+});


### PR DESCRIPTION
Useful for implementing widgets with custom handlers using onPress. For example, a DatePickerAndroid implementation can be done via:

```jsx

<GiftedForm.RowValueWidget
  title='Date of birth'
  name='dateOfBirth' // mandatory
  displayValue='dateOfBirth'
  image={<Icon name={tk+'-calendar'} size={iconSize} style={styles.icon} />}
  value={this.state.dateOfBirth}
  onPress={() => {
    DatePickerAndroid.open({
      date: (this.state.dateOfBirth)? Date.parse(this.state.dateOfBirth): new Date(),
      maxDate: new Date(),
      mode: 'spinner',
    }).then((r)=>{
      if (r.action !== DatePickerAndroid.dismissedAction) {
                      // Selected year, month (0-11), day
      this.setState({dateOfBirth:`${r.month}/${r.day}/${r.year}`});
    }
    }).catch((code,message)=>console.warn('Cannot open date picker', message));
}}
/>

```

With this widget. 