### PR TITLE
Allow font scalling prop

### DIFF
--- a/widgets/ErrorsWidget.js
+++ b/widgets/ErrorsWidget.js
@@ -10,6 +10,12 @@ const WidgetMixin = require('../mixins/WidgetMixin.js');
 module.exports = React.createClass({
   mixins: [WidgetMixin],
 
+  getDefaultProps() {
+    return {
+      allowTextFontScaling: true,
+    };
+  },
+
   render() {
     var errors = this.props.form.state.errors;
     if (errors.length > 0) {
@@ -18,6 +24,7 @@ module.exports = React.createClass({
           style={this.getStyle('errorContainer')}
         >
           <Text
+            allowFontScaling={this.props.allowTextFontScaling}
             style={this.getStyle('errorText')}
           >
             {errors.join('\n')}

--- a/widgets/GroupWidget.js
+++ b/widgets/GroupWidget.js
@@ -12,6 +12,7 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       type: 'GroupWidget',
+      allowTextFontScaling: true,
       // @todo proptypes
     };
   },
@@ -35,6 +36,7 @@ module.exports = React.createClass({
       return (
           <View>
             <Text
+                allowFontScaling={this.props.allowTextFontScaling}
                 style={this.getStyle('headerTitle')}
                 {...this.props}
             >

--- a/widgets/NoticeWidget.js
+++ b/widgets/NoticeWidget.js
@@ -10,18 +10,20 @@ var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 module.exports = React.createClass({
   mixins: [WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'NoticeWidget',
+      allowTextFontScaling: true,
     };
   },
-  
+
   render() {
     return (
       <View>
         <View style={this.getStyle('noticeRow')}>
           <Text
+            allowFontScaling={this.props.allowTextFontScaling}
             style={this.getStyle('noticeTitle')}
             {...this.props}
           >
@@ -31,7 +33,7 @@ module.exports = React.createClass({
       </View>
     );
   },
-  
+
   defaultStyles: {
     noticeRow: {
       paddingBottom: 10,
@@ -42,7 +44,6 @@ module.exports = React.createClass({
     noticeTitle: {
       fontSize: 13,
       color: '#9b9b9b',
-    },  
+    },
   },
 });
-

--- a/widgets/OptionWidget.js
+++ b/widgets/OptionWidget.js
@@ -13,14 +13,15 @@ var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 module.exports = React.createClass({
   mixins: [WidgetMixin],
-  
+
   getDefaultProps() {
     return ({
       // onChange: null,
       type: 'OptionWidget',
+      allowTextFontScaling: true,
     });
   },
-  
+
   _renderCheckmark() {
     if (this.state.value === true) {
       return (
@@ -33,17 +34,17 @@ module.exports = React.createClass({
     }
     return null;
   },
-  
+
   _onClose() {
     if (this.props.multiple === false) {
       this.props.unSelectAll();
       this._onChange(true);
-      
+
       if (typeof this.props.onSelect === 'function') {
         // console.log('onSelect');
         this.props.onSelect(this.props.value);
       }
-      
+
       if (typeof this.props.onClose === 'function') {
         this.props.onClose(this.props.title, this.props.navigator);
       }
@@ -51,7 +52,7 @@ module.exports = React.createClass({
       this._onChange(!this.state.value)
     }
   },
-  
+
   render() {
     return (
       <View style={this.getStyle('rowContainer')}>
@@ -62,16 +63,20 @@ module.exports = React.createClass({
         >
           <View style={this.getStyle('row')}>
             {this._renderImage()}
-            <Text numberOfLines={1} style={this.getStyle('switchTitle')}>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={this.getStyle('switchTitle')}
+            >
               {this.props.title}
             </Text>
             {this._renderCheckmark()}
-          </View>        
+          </View>
         </TouchableHighlight>
       </View>
     );
   },
-  
+
   defaultStyles: {
     rowImage: {
       height: 20,
@@ -102,4 +107,3 @@ module.exports = React.createClass({
     },
   },
 });
-

--- a/widgets/RowValueWidget.js
+++ b/widgets/RowValueWidget.js
@@ -13,15 +13,16 @@ var TimerMixin = require('react-timer-mixin');
 
 module.exports = React.createClass({
   mixins: [TimerMixin, WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'RowValueWidget',
       onPress: () => {},
       disclosure: true,
+      allowTextFontScaling: true,
     };
   },
-  
+
   render() {
     return (
       <View style={this.getStyle('rowContainer')}>
@@ -36,16 +37,24 @@ module.exports = React.createClass({
         >
           <View style={this.getStyle('row')}>
             {this._renderImage()}
-            <Text numberOfLines={1} style={this.getStyle('title')}>{this.props.title}</Text>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={this.getStyle('title')}
+            >{this.props.title}</Text>
             <View style={this.getStyle('alignRight')}>
-              <Text numberOfLines={1} style={this.getStyle('value')}>{this.state.value}</Text>
+              <Text
+                numberOfLines={1}
+                allowFontScaling={this.props.allowTextFontScaling}
+                style={this.getStyle('value')}
+              >{this.state.value}</Text>
             </View>
           </View>
         </TouchableHighlight>
       </View>
     );
   },
-  
+
   defaultStyles: {
     rowImage: {
       height: 20,

--- a/widgets/RowWidget.js
+++ b/widgets/RowWidget.js
@@ -13,15 +13,16 @@ var TimerMixin = require('react-timer-mixin');
 
 module.exports = React.createClass({
   mixins: [TimerMixin, WidgetMixin],
-  
+
   getDefaultProps() {
     return {
       type: 'RowWidget',
       onPress: () => {},
       disclosure: true,
+      allowTextFontScaling: true,
     };
   },
-  
+
   _renderDisclosure() {
     if (this.props.disclosure === true) {
       return (
@@ -34,7 +35,7 @@ module.exports = React.createClass({
     }
     return null;
   },
-  
+
   render() {
     return (
       <View style={this.getStyle('rowContainer')}>
@@ -49,14 +50,18 @@ module.exports = React.createClass({
         >
           <View style={this.getStyle('row')}>
             {this._renderImage()}
-            <Text numberOfLines={1} style={this.getStyle('title')}>{this.props.title}</Text>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={this.getStyle('title')}
+            >{this.props.title}</Text>
             {this._renderDisclosure()}
           </View>
         </TouchableHighlight>
       </View>
     );
   },
-  
+
   defaultStyles: {
     rowImage: {
       height: 20,

--- a/widgets/SelectCountryWidget.js
+++ b/widgets/SelectCountryWidget.js
@@ -1039,6 +1039,7 @@ module.exports = React.createClass({
       onClose: () => {},
       code: 'alpha2',
       autoFocus: false,
+      allowTextFontScaling: true,
     };
   },
 
@@ -1834,9 +1835,11 @@ module.exports = React.createClass({
               }}
             />
 
-            <Text numberOfLines={1} style={{
-              flex: 1,
-            }}>{rowData.name}</Text>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={{flex: 1}}
+            >{rowData.name}</Text>
           </View>
         </TouchableHighlight>
       );
@@ -1865,9 +1868,11 @@ module.exports = React.createClass({
                 marginRight: 10,
               }}
             />
-            <Text numberOfLines={1} style={{
-              flex: 1,
-            }}>{rowData.name}</Text>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={{flex: 1}}
+            >{rowData.name}</Text>
           </View>
         </TouchableHighlight>
       );

--- a/widgets/SwitchWidget.js
+++ b/widgets/SwitchWidget.js
@@ -34,6 +34,7 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       type: 'SwitchWidget',
+      allowTextFontScaling: true,
     };
   },
 
@@ -43,7 +44,11 @@ module.exports = React.createClass({
         <View style={this.getStyle('row')}>
           {this._renderImage()}
 
-          <Text numberOfLines={1} style={this.getStyle('switchTitle')}>{this.props.title}</Text>
+          <Text
+            numberOfLines={1}
+            allowFontScaling={this.props.allowTextFontScaling}
+            style={this.getStyle('switchTitle')}
+          >{this.props.title}</Text>
           <View style={this.getStyle('switchAlignRight')}>
             <GiftedSwitch
               style={this.getStyle('switch')}

--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -20,25 +20,27 @@ module.exports = React.createClass({
       underlined: false,
       onTextInputFocus: (value) => value,
       onTextInputBlur: (value) => value
+      allowTextFontScaling: true,
     }
   },
-  
+
   getInitialState() {
     return {
       focused: false,
     }
   },
-  
+
   _renderTitle() {
     if (this.props.title !== '') {
       return (
-        <Text 
+        <Text
           numberOfLines={1}
+          allowFontScaling={this.props.allowTextFontScaling}
           style={this.getStyle(['textInputTitleInline'])}
         >
           {this.props.title}
         </Text>
-      );      
+      );
     }
     return (
       <View style={this.getStyle(['spacer'])}/>
@@ -46,25 +48,29 @@ module.exports = React.createClass({
   },
 
   _renderRow() {
-    
+
     if (this.props.inline === false) {
       return (
         <View style={this.getStyle(['rowContainer'])}>
           <View style={this.getStyle(['titleContainer'])}>
             {this._renderImage()}
-            <Text numberOfLines={1} style={this.getStyle(['textInputTitle'])}>{this.props.title}</Text>
+            <Text
+              numberOfLines={1}
+              allowFontScaling={this.props.allowTextFontScaling}
+              style={this.getStyle(['textInputTitle'])}
+            >{this.props.title}</Text>
           </View>
-          
+
           <TextInput
             ref='input'
             style={this.getStyle(['textInput'])}
-          
+
             {...this.props}
-            
+
             onFocus={this.onFocus}
             onBlur={this.onBlur}
-            
-            
+
+
             onChangeText={this._onChange}
             value={this.state.value}
           />
@@ -72,7 +78,7 @@ module.exports = React.createClass({
           {this._renderUnderline()}
         </View>
       );
-    } 
+    }
     return (
       <View style={this.getStyle(['rowContainer'])}>
         <View style={this.getStyle(['row'])}>
@@ -83,10 +89,10 @@ module.exports = React.createClass({
             style={this.getStyle(['textInputInline'])}
 
             {...this.props}
-            
+
             onFocus={this.onFocus}
             onBlur={this.onBlur}
-            
+
             onChangeText={this._onChange}
             value={this.state.value}
           />
@@ -97,7 +103,7 @@ module.exports = React.createClass({
     );
 
   },
-  
+
   onFocus() {
     this.setState({
       focused: true,
@@ -108,19 +114,19 @@ module.exports = React.createClass({
     if (newText !== oldText) {
       this._onChange(newText);
     }
-    
+
   },
-  
+
   onBlur() {
     this.setState({
       focused: false,
-    });    
+    });
     this.props.onBlur();
     this.props.onTextInputBlur(this.state.value);
   },
-  
-  
-  
+
+
+
   _renderUnderline() {
     if (this.props.underlined === true) {
       if (this.state.focused === false) {
@@ -128,7 +134,7 @@ module.exports = React.createClass({
           <View
             style={this.getStyle(['underline', 'underlineIdle'])}
           />
-        );        
+        );
       }
       return (
         <View
@@ -138,11 +144,11 @@ module.exports = React.createClass({
     }
     return null;
   },
-  
+
   render() {
     return this._renderRow();
   },
-  
+
   defaultStyles: {
     rowImage: {
       height: 20,

--- a/widgets/ValidationErrorWidget.js
+++ b/widgets/ValidationErrorWidget.js
@@ -10,18 +10,20 @@ var WidgetMixin = require('../mixins/WidgetMixin.js');
 module.exports = React.createClass({
   mixins: [WidgetMixin],
 
-  
+
   getDefaultProps() {
     return {
       type: 'ValidationErrorWidget',
+      allowTextFontScaling: true,
     };
   },
-  
+
   render() {
     return (
       <View>
         <View style={this.getStyle('validationErrorRow')}>
           <Text
+            allowFontScaling={this.props.allowTextFontScaling}
             style={this.getStyle('validationError')}
             {...this.props}
           >
@@ -31,7 +33,7 @@ module.exports = React.createClass({
       </View>
     );
   },
-  
+
 
   defaultStyles: {
     validationErrorRow: {
@@ -44,5 +46,5 @@ module.exports = React.createClass({
       color: '#ff001A',
     },
   },
-  
+
 });


### PR DESCRIPTION
On IOS the user can set the font size in the accessibility screen. 
This can break certain visual elements so you may want to disable the font scaling option.
The default value is true. I set the defaults prop to be true so its backwards compatible.

Links:
https://facebook.github.io/react-native/docs/text.html
http://joshbuchea.com/react-native-text-size-font-scaling/