### PR TITLE
React 16 compatability

### DIFF
--- a/GiftedForm.js
+++ b/GiftedForm.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 const GiftedFormManager = require('./GiftedFormManager');
 
@@ -25,7 +27,7 @@ const LoadingWidget = require('./widgets/LoadingWidget');
 const HiddenWidget = require('./widgets/HiddenWidget');
 const ErrorsWidget = require('./widgets/ErrorsWidget');
 
-const GiftedForm = React.createClass({
+const GiftedForm = createReactClass({
   mixins: [ ContainerMixin ],
 
   statics: {
@@ -62,11 +64,11 @@ const GiftedForm = React.createClass({
   },
 
   propTypes: {
-    isModal: React.PropTypes.bool,
-    clearOnClose: React.PropTypes.bool,
-    validators: React.PropTypes.object,
-    defaults: React.PropTypes.object,
-    openModal: React.PropTypes.func,
+    isModal: PropTypes.bool,
+    clearOnClose: PropTypes.bool,
+    validators: PropTypes.object,
+    defaults: PropTypes.object,
+    openModal: PropTypes.func,
   },
 
   componentWillUnmount() {
@@ -96,7 +98,7 @@ const GiftedForm = React.createClass({
   },
 });
 
-var GiftedFormModal = React.createClass({
+var GiftedFormModal = createReactClass({
   mixins: [ ContainerMixin ],
 
   getDefaultProps() {
@@ -106,7 +108,7 @@ var GiftedFormModal = React.createClass({
   },
 
   propTypes: {
-    isModal: React.PropTypes.bool,
+    isModal: PropTypes.bool,
   },
 
   render() {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Form component for React Native.
 ```js
 var { GiftedForm, GiftedFormManager } = require('react-native-gifted-form');
 
-var FormComponent = React.createClass({
+var FormComponent = createReactClass({
   render() {
     return (
       <GiftedForm

--- a/mixins/ContainerMixin.js
+++ b/mixins/ContainerMixin.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   ScrollView,
   View,
@@ -11,10 +12,10 @@ var GiftedFormManager = require('../GiftedFormManager');
 module.exports = {
 
   propTypes: {
-    formName: React.PropTypes.string,
-    scrollOnTap: React.PropTypes.bool,
-    scrollEnabled: React.PropTypes.bool,
-    formStyles: React.PropTypes.object,
+    formName: PropTypes.string,
+    scrollOnTap: PropTypes.bool,
+    scrollEnabled: PropTypes.bool,
+    formStyles: PropTypes.object,
     // navigator: ,
   },
 

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -1,7 +1,6 @@
-var React = require('react');
-var {
-  Image
-} = require('react-native')
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image } from 'react-native';
 
 
 var GiftedFormManager = require('../GiftedFormManager');
@@ -15,20 +14,20 @@ module.exports = {
   },
 
   propTypes: {
-    name: React.PropTypes.string,
-    title: React.PropTypes.string,
-    formName: React.PropTypes.string,
+    name: PropTypes.string,
+    title: PropTypes.string,
+    formName: PropTypes.string,
     // image: ,
-    widgetStyles: React.PropTypes.object,
-    formStyles: React.PropTypes.object,
-    validationImage: React.PropTypes.bool,
-    openModal: React.PropTypes.func,
+    widgetStyles: PropTypes.object,
+    formStyles: PropTypes.object,
+    validationImage: PropTypes.bool,
+    openModal: PropTypes.func,
     // navigator: ,
-    onFocus: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    validateOnEmpty: React.PropTypes.bool,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    validateOnEmpty: PropTypes.bool,
     // If we want to store the state elsewhere (Redux store, for instance), we can use value and Form's onValueChange prop
-    value: React.PropTypes.any,
+    value: PropTypes.any,
   },
 
   getDefaultProps() {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
   },
   "homepage": "https://github.com/FaridSafi/react-native-gifted-form#readme",
   "dependencies": {
-    "apsl-react-native-button": "~3.0.0",
-    "moment": "~2.18.1",
-    "react-native-button": "~1.8.2",
+    "apsl-react-native-button": "^3.1.0",
+    "create-react-class": "^15.6.2",
+    "moment": "^2.19.1",
+    "prop-types": "^15.6.0",
+    "react-native-button": "^2.1.0",
     "react-native-gifted-spinner": "~0.1.0",
-    "react-native-google-places-autocomplete": "~1.2.0",
+    "react-native-google-places-autocomplete": "^1.3.6",
     "react-timer-mixin": "~0.13.3",
-    "validator": "~7.1.0"
+    "validator": "^9.0.0"
   }
 }

--- a/widgets/DatePickerIOSWidget.js
+++ b/widgets/DatePickerIOSWidget.js
@@ -1,14 +1,15 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   DatePickerIOS,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/ErrorsWidget.js
+++ b/widgets/ErrorsWidget.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {
   View,
   Text,
@@ -7,7 +8,7 @@ import {
 
 const WidgetMixin = require('../mixins/WidgetMixin.js');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   render() {

--- a/widgets/GooglePlacesWidget.js
+++ b/widgets/GooglePlacesWidget.js
@@ -1,11 +1,12 @@
-var React = require('react');
+import React from 'react';
+import createReactClass from 'create-react-class';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 var {GooglePlacesAutocomplete} = require('react-native-google-places-autocomplete');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {

--- a/widgets/GroupWidget.js
+++ b/widgets/GroupWidget.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {
   View,
   Text
@@ -6,7 +7,7 @@ import {
 
 var WidgetMixin = require('../mixins/WidgetMixin');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {

--- a/widgets/HiddenWidget.js
+++ b/widgets/HiddenWidget.js
@@ -1,12 +1,13 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   componentDidMount() {

--- a/widgets/LoadingWidget.js
+++ b/widgets/LoadingWidget.js
@@ -1,16 +1,17 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   TouchableHighlight,
   Image,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 var GiftedSpinner = require('react-native-gifted-spinner');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/ModalWidget.js
+++ b/widgets/ModalWidget.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import {
   View,
   Text,
@@ -16,7 +18,7 @@ var TimerMixin = require('react-timer-mixin');
 
 var moment = require('moment');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [TimerMixin, WidgetMixin],
 
   getDefaultProps() {
@@ -31,12 +33,12 @@ module.exports = React.createClass({
   },
 
   propTypes: {
-    type: React.PropTypes.string,
-    scrollEnabled: React.PropTypes.bool,
-    disclosure: React.PropTypes.bool,
-    cancelable: React.PropTypes.bool,
-    displayValue: React.PropTypes.string,
-    onClose: React.PropTypes.func
+    type: PropTypes.string,
+    scrollEnabled: PropTypes.bool,
+    disclosure: PropTypes.bool,
+    cancelable: PropTypes.bool,
+    displayValue: PropTypes.string,
+    onClose: PropTypes.func
   },
 
   getInitialState() {

--- a/widgets/NoticeWidget.js
+++ b/widgets/NoticeWidget.js
@@ -1,14 +1,15 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/OptionWidget.js
+++ b/widgets/OptionWidget.js
@@ -1,17 +1,18 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   TouchableHighlight,
   Image,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/RowValueWidget.js
+++ b/widgets/RowValueWidget.js
@@ -1,17 +1,18 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   TouchableHighlight,
   Image,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 var TimerMixin = require('react-timer-mixin');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [TimerMixin, WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/RowWidget.js
+++ b/widgets/RowWidget.js
@@ -1,17 +1,18 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   TouchableHighlight,
   Image,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 var TimerMixin = require('react-timer-mixin');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [TimerMixin, WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/SelectCountryWidget.js
+++ b/widgets/SelectCountryWidget.js
@@ -1,7 +1,8 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View, ListView, Text, TouchableHighlight, TextInput, Image, PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 var OptionWidget = require('./OptionWidget.js');
@@ -260,7 +261,7 @@ var countries =
 ];
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   statics: {

--- a/widgets/SelectWidget.js
+++ b/widgets/SelectWidget.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {
   View,
 } from 'react-native';
@@ -6,7 +7,7 @@ import {
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {

--- a/widgets/SeparatorWidget.js
+++ b/widgets/SeparatorWidget.js
@@ -1,12 +1,13 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/SubmitWidget.js
+++ b/widgets/SubmitWidget.js
@@ -1,4 +1,6 @@
-var React = require('react');
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 
 var {View, Text} = require('react-native')
@@ -11,7 +13,7 @@ var GiftedFormManager = require('../GiftedFormManager');
 
 
 // @todo to test with validations
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {
@@ -27,12 +29,12 @@ module.exports = React.createClass({
   },
 
   propTypes: {
-    onSubmit: React.PropTypes.func,
-    preSubmit: React.PropTypes.func,
-    isDisabled: React.PropTypes.bool,
-    activityIndicatorColor: React.PropTypes.string,
-    requiredMessage: React.PropTypes.string,
-    notValidMessage: React.PropTypes.string,
+    onSubmit: PropTypes.func,
+    preSubmit: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    activityIndicatorColor: PropTypes.string,
+    requiredMessage: PropTypes.string,
+    notValidMessage: PropTypes.string,
   },
 
   getInitialState() {

--- a/widgets/SwitchWidget.js
+++ b/widgets/SwitchWidget.js
@@ -1,15 +1,16 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   Switch,
   Platform,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
-var GiftedSwitch = React.createClass({
+var GiftedSwitch = createReactClass({
   _getSwitch() {
     return (
       <Switch
@@ -28,7 +29,7 @@ var GiftedSwitch = React.createClass({
 
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {

--- a/widgets/TextAreaWidget.js
+++ b/widgets/TextAreaWidget.js
@@ -1,14 +1,15 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   TextInput,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
   
   getDefaultProps() {

--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -1,15 +1,16 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text,
   TextInput,
   PixelRatio
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   getDefaultProps() {

--- a/widgets/ValidationErrorWidget.js
+++ b/widgets/ValidationErrorWidget.js
@@ -1,13 +1,14 @@
-var React = require('react');
-var {
+import React from 'react';
+import createReactClass from 'create-react-class';
+import {
   View,
   Text
-} = require('react-native')
+} from 'react-native';
 
 var WidgetMixin = require('../mixins/WidgetMixin.js');
 
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [WidgetMixin],
 
   

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,65 @@
 # yarn lockfile v1
 
 
-apsl-react-native-button@~3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/apsl-react-native-button/-/apsl-react-native-button-3.0.2.tgz#705d5658b59b615cf0c3d62f0c40b80d1d2c9f81"
+apsl-react-native-button@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/apsl-react-native-button/-/apsl-react-native-button-3.1.0.tgz#8fe6ebf734cc5f1006c6eb1d54370abc3c3833f5"
   dependencies:
     lodash.isequal "^4.1.4"
+    prop-types "^15.5.10"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
+create-react-class@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
+fbjs@^0.8.16, fbjs@^0.8.9:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
+js-tokens@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -16,33 +70,79 @@ lodash.isequal@^4.1.4:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-moment@~2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+loose-envify@^1.0.0, loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
+moment@^2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.10, prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 qs@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.1.tgz#801fee030e0b9450d6385adc48a4cc55b44aedfc"
 
-react-native-button@~1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/react-native-button/-/react-native-button-1.8.2.tgz#49e5cadd22ee443adea52a85539d288aa2117ade"
+react-native-button@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-button/-/react-native-button-2.1.0.tgz#a39e23292922afeea4f7be141dd43e18f1b51876"
+  dependencies:
+    prop-types "^15.5.10"
 
 react-native-gifted-spinner@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/react-native-gifted-spinner/-/react-native-gifted-spinner-0.1.0.tgz#2c76094fa0469c59e96dead270cd5bca5a55962a"
 
-react-native-google-places-autocomplete@~1.2.0:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/react-native-google-places-autocomplete/-/react-native-google-places-autocomplete-1.2.12.tgz#714c731be35bfca190239d98cbc7e0d518b38d98"
+react-native-google-places-autocomplete@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/react-native-google-places-autocomplete/-/react-native-google-places-autocomplete-1.3.6.tgz#352ba0858f647c0c2caba448b6b6296984d8c7af"
   dependencies:
     lodash.debounce "^4.0.8"
+    prop-types "^15.5.10"
     qs "^5.2.0"
 
 react-timer-mixin@~0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 
-validator@~7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-7.1.0.tgz#331695afc7e6d72f980bddd68aa296d6b3d6c8b6"
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+ua-parser-js@^0.7.9:
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+validator@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-9.0.0.tgz#6c1ef955e007af704adea86ae8a76da84a6c172e"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"


### PR DESCRIPTION
- Use 'prop-types' package instead of `React.PropTypes`
- Use `createReactClass` from `create-react-class` instead of `React.createClass`
- Update some `require` statements to `import`
- Updated dependencies (fixes issues with latest MetroBundler and moment)