### PR TITLE
ErrorsWidget - Add missing type prop. Add empty view+style.

### DIFF
--- a/widgets/ErrorsWidget.js
+++ b/widgets/ErrorsWidget.js
@@ -11,6 +11,12 @@ const WidgetMixin = require('../mixins/WidgetMixin.js');
 module.exports = createReactClass({
   mixins: [WidgetMixin],
 
+  getDefaultProps() {
+      return {
+          type: 'ErrorsWidget',
+      }
+  },
+
   render() {
     var errors = this.props.form.state.errors;
     if (errors.length > 0) {
@@ -26,7 +32,7 @@ module.exports = createReactClass({
         </View>
       );
     }
-    return null;
+    return <View style={this.getStyle('errorEmptyContainer')} />;
   },
 
   defaultStyles: {
@@ -35,6 +41,9 @@ module.exports = createReactClass({
     },
     errorText: {
       color: '#ff0000',
+    },
+    errorEmptyContainer: {
+
     },
   },
 


### PR DESCRIPTION
1) Added missing type prop. Without it you cannot apply any styles. 
2) Added a styleable empty view if there aren't any errors. This enables you to style the widget even if there aren't any errors. In my case I want the errors widget to have a height so it doesn't jump around when errors are generated. 