### PR TITLE
Custom validatable icon rendering

### DIFF
--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -240,6 +240,7 @@ module.exports = {
 
     return null;
   },
+
   _renderCustomValidationView() {
     var validators = null;
     if (this.props.displayValue) {
@@ -266,13 +267,12 @@ module.exports = {
     }
 
     const hasValidationErrors = this.state.validationErrorMessage !== null;
-    const hasImageProp = this.props.image !== null;
-    const isOptionWidget = this.props.type === 'OptionWidget'
+    const isOptionWidget = this.props.type === 'OptionWidget';
     const shouldShowValidationImage = this.props.validationImage === true;
 
     if (this.props.customValidationView) {
       const showValidation = hasValue && !isOptionWidget && shouldShowValidationImage && toValidate;
-      const isValid = !hasValidationErrors
+      const isValid = !hasValidationErrors;
       return this.props.customValidationView(showValidation, isValid)
     }
     return null;

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -22,6 +22,7 @@ module.exports = {
     formStyles: PropTypes.object,
     validationImage: PropTypes.bool,
     openModal: PropTypes.func,
+    customValidationView: PropTypes.func,
     // navigator: ,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,
@@ -43,6 +44,7 @@ module.exports = {
       navigator: null,
       onFocus: () => {},
       onBlur: () => {},
+      customValidationView: () => {},
       validateOnEmpty: false,
     };
   },
@@ -215,7 +217,6 @@ module.exports = {
 
     if (hasValue && hasImageProp && !isOptionWidget && shouldShowValidationImage && toValidate) {
       const imageSrc = hasValidationErrors ? require('../icons/delete_sign.png'):require('../icons/checkmark.png');
-
       return (
         <Image
           style={this.getStyle('rowImage')}
@@ -237,6 +238,43 @@ module.exports = {
       );
     }
 
+    return null;
+  },
+  _renderCustomValidationView() {
+    var validators = null;
+    if (this.props.displayValue) {
+      // in case of modal widget
+      validators = GiftedFormManager.getValidators(this.props.formName, this.props.displayValue);
+    } else {
+      validators = GiftedFormManager.getValidators(this.props.formName, this.props.name);
+    }
+
+    let toValidate = false;
+    if (Array.isArray(validators.validate)) {
+      if (validators.validate.length > 0) {
+        toValidate = true;
+      }
+    }
+
+    // @todo image delete_sign / checkmark should be editable via option
+    // @todo options enable live validation
+
+    let hasValue = typeof this.state.value !== 'undefined' && this.state.value !== '';
+
+    if (this.props.validateOnEmpty) {
+      hasValue = true;
+    }
+
+    const hasValidationErrors = this.state.validationErrorMessage !== null;
+    const hasImageProp = this.props.image !== null;
+    const isOptionWidget = this.props.type === 'OptionWidget'
+    const shouldShowValidationImage = this.props.validationImage === true;
+
+    if (this.props.customValidationView) {
+      const showValidation = hasValue && !isOptionWidget && shouldShowValidationImage && toValidate;
+      const isValid = !hasValidationErrors
+      return this.props.customValidationView(showValidation, isValid)
+    }
     return null;
   },
 };

--- a/mixins/WidgetMixin.js
+++ b/mixins/WidgetMixin.js
@@ -220,7 +220,7 @@ module.exports = {
       return (
         <Image
           style={this.getStyle('rowImage')}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
           source={imageSrc}
         />
       );
@@ -232,7 +232,7 @@ module.exports = {
       return (
         <Image
           style={this.getStyle('rowImage')}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
           source={this.props.image}
         />
       );

--- a/widgets/ModalWidget.js
+++ b/widgets/ModalWidget.js
@@ -276,6 +276,8 @@ module.exports = createReactClass({
       >
         <View style={this.getStyle('row')}>
           {this._renderImage()}
+          {this._renderCustomValidationView()}
+
           <Text numberOfLines={1} style={this.getStyle('modalTitle')}>{this.props.title}</Text>
           <View style={this.getStyle('alignRight')}>
             <Text numberOfLines={1} style={this.getStyle('modalValue')}>{this.state.value}</Text>

--- a/widgets/ModalWidget.js
+++ b/widgets/ModalWidget.js
@@ -54,7 +54,7 @@ module.exports = createReactClass({
       return (
         <Image
           style={this.getStyle('disclosure')}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
           source={require('../icons/disclosure.png')}
         />
       );
@@ -114,7 +114,7 @@ module.exports = createReactClass({
                   marginLeft: 10,
                   tintColor: '#097881',
                 }}
-                resizeMode={Image.resizeMode.contain}
+                resizeMode="contain"
                 source={require('../icons/close.png')}
               />
             </TouchableOpacity>
@@ -139,7 +139,7 @@ module.exports = createReactClass({
                 marginRight: 10,
                 tintColor: '#097881',
               }}
-              resizeMode={Image.resizeMode.contain}
+              resizeMode="contain"
               source={require('../icons/check.png')}
             />
           </TouchableOpacity>

--- a/widgets/OptionWidget.js
+++ b/widgets/OptionWidget.js
@@ -27,7 +27,7 @@ module.exports = createReactClass({
       return (
         <Image
           style={this.getStyle('checkmark')}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
           source={require('../icons/check.png')}
         />
       );

--- a/widgets/OptionWidget.js
+++ b/widgets/OptionWidget.js
@@ -63,6 +63,7 @@ module.exports = createReactClass({
         >
           <View style={this.getStyle('row')}>
             {this._renderImage()}
+            {this._renderCustomValidationView()}
             <Text numberOfLines={1} style={this.getStyle('switchTitle')}>
               {this.props.title}
             </Text>

--- a/widgets/RowWidget.js
+++ b/widgets/RowWidget.js
@@ -28,7 +28,7 @@ module.exports = createReactClass({
       return (
         <Image
           style={this.getStyle('disclosure')}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
           source={require('../icons/disclosure.png')}
         />
       );

--- a/widgets/SelectCountryWidget.js
+++ b/widgets/SelectCountryWidget.js
@@ -1857,7 +1857,7 @@ module.exports = createReactClass({
           }}>
             <Image
               key={rowData.alpha2+'Image'}
-              resizeMode={Image.resizeMode.contain}
+              resizeMode="contain"
               source={image}
               style={{
                 height: 30,

--- a/widgets/SwitchWidget.js
+++ b/widgets/SwitchWidget.js
@@ -43,6 +43,7 @@ module.exports = createReactClass({
       <View style={this.getStyle('rowContainer')}>
         <View style={this.getStyle('row')}>
           {this._renderImage()}
+          {this._renderCustomValidationView()}
 
           <Text numberOfLines={1} style={this.getStyle('switchTitle')}>{this.props.title}</Text>
           <View style={this.getStyle('switchAlignRight')}>

--- a/widgets/TextAreaWidget.js
+++ b/widgets/TextAreaWidget.js
@@ -21,6 +21,7 @@ module.exports = createReactClass({
   render() {
     return (
       <View style={this.getStyle('textAreaRow')}>
+        {this._renderCustomValidationView()}
         <TextInput
           style={this.getStyle('textArea')}
           multiline={true}

--- a/widgets/TextInputWidget.js
+++ b/widgets/TextInputWidget.js
@@ -53,6 +53,7 @@ module.exports = createReactClass({
         <View style={this.getStyle(['rowContainer'])}>
           <View style={this.getStyle(['titleContainer'])}>
             {this._renderImage()}
+            {this._renderCustomValidationView()}
             <Text numberOfLines={1} style={this.getStyle(['textInputTitle'])}>{this.props.title}</Text>
           </View>
           
@@ -78,6 +79,7 @@ module.exports = createReactClass({
       <View style={this.getStyle(['rowContainer'])}>
         <View style={this.getStyle(['row'])}>
           {this._renderImage()}
+          {this._renderCustomValidationView()}
           {this._renderTitle()}
           <TextInput
             ref='input'


### PR DESCRIPTION
- First i had to fix "Image.resizeMode.contain" bug. Because this variable is no longer exposing in RN 0.57
- The reason to implement this feature is to use any custom element as the left icon depending on the validation state. For example i created a sample renderer function to render react-native-vector-icons/Ionicons:

```javascript
const getValidationRenderer = (icon, defaultColor, changeIconOnValidation) => {
      return (showValidation, isValid) => {
        let color = defaultColor;
        let iconName = icon;
        let size = 22;
        if (showValidation) {
          color = isValid ? Colors.green10 : Colors.red10;
          if (changeIconOnValidation) {
            iconName = isValid ? 'md-checkmark' : 'md-close';
          }
        }
        return (
          <View style={{ width: 32, paddingLeft: 10, alignItems: 'center', justifyContent: 'center' }}>
            <Icon name={iconName} size={size} color={color} />
          </View>
        );
      };
    };

..
..
..

<GiftedForm.TextInputWidget
          name='emailAddress' // mandatory
          title='Email address'
          placeholder='example@nomads.ly'
          keyboardType='email-address'
          clearButtonMode='while-editing'
          customValidationView={getValidationRenderer('ios-mail', Colors.blue10, false)}
/>

```

